### PR TITLE
chore: bump up analyzer and sdk version

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,7 +48,7 @@ class MyHomePage extends HookWidget {
             ),
             Text(
               '${counter.value}',
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],
         ),

--- a/lib/src/lint/hook_widget_visitor.dart
+++ b/lib/src/lint/hook_widget_visitor.dart
@@ -31,7 +31,7 @@ class HookWidgetVisitor<C> extends SimpleAstVisitor<void> {
   void visitClassDeclaration(ClassDeclaration node) {
     log.finer('HookWidgetVisitor: visit($node)');
 
-    switch (node.extendsClause?.superclass.name.name) {
+    switch (node.extendsClause?.superclass.name2.toString()) {
       case 'HookWidget':
       case 'HookConsumerWidget':
         final context = contextBuilder();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ repository: https://github.com/mj-hd/flutter_hooks_lint_plugin
 version: 0.6.1
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: ">=1.20.0"
 
 dependencies:
-  analyzer: ^5.2.0
-  analyzer_plugin: ">=0.11.0 <0.12.0"
+  analyzer: ^6.4.1
+  analyzer_plugin: ^0.11.3
   logging: ^1.0.0
   yaml: ^3.1.0
   path: ^1.8.0


### PR DESCRIPTION
### DesignDoc
- https://github.com/WinTicket/app/discussions/8621

### Motivation
- 現状、Appで使っているHooksLintで使われているanalyzerのバージョン互換性により、App内のパッケージ更新に支障が出ている
  - https://github.com/WinTicket/app/discussions/8516
  - https://github.com/WinTicket/app/pull/8585

### Changes
- analyzerのバージョンを上げた
- sdkのバージョンを上げた